### PR TITLE
Fix off-by-one error when writing out voxel grid

### DIFF
--- a/src/data/voxelize_utils.cpp
+++ b/src/data/voxelize_utils.cpp
@@ -245,10 +245,11 @@ void saveVoxelGrid(const VoxelGrid& grid, const std::string& directory, const st
         }
 
         // Write maxLabel appropriately to file.
-        counter = counter + 1;
+        assert(counter < numElements);
         outputLabels[counter] = maxLabel;
         outputTensorOccluded[counter] = isOccluded;
         outputTensorInvalid[counter] = (uint32_t)grid.isInvalid(x, y, z);
+        counter = counter + 1;
       }
     }
   }


### PR DESCRIPTION
When writing the voxel grids to binary, the `counter` variable has an off-by-one error.
Besides the invalid memory access at the last vector position, this causes all voxels to be shifted one voxel upwards. Voxels in the top row are additionally shifted horizontally onto the next y-position.

I think that the voxelized annotations from http://semantic-kitti.org/dataset.html#download (downloaded on 2020-06-09) do also exhibit this error.