### PR TITLE
Remove unnecessary <matio.h> include

### DIFF
--- a/src/gen_data.cpp
+++ b/src/gen_data.cpp
@@ -1,4 +1,3 @@
-#include <matio.h>
 #include <stdint.h>
 #include <fstream>
 #include <iomanip>


### PR DESCRIPTION
<matio.h> is a non-standard header that is not contained in any of the dependencies which caused the build to fail